### PR TITLE
Uses svc-client with service client methods accessed by an object path.

### DIFF
--- a/lib/reduxSvcClientThunk.js
+++ b/lib/reduxSvcClientThunk.js
@@ -32,18 +32,15 @@ module.exports = serviceName => (methodPath, customActions = {}) => params => (d
   const successAction = createMethodAction(success);
   const failureAction = createMethodAction(failure);
   const serviceFailureAction = createServiceFailureAction(serviceFailureActionType);
-  const method = get(svcClient, methodPath);
+  const svcMethod = get(svcClient, methodPath);
 
   dispatch(requestAction(undefined, params));
 
-  return method(params)
+  return svcMethod(params)
     .then(data => dispatch(successAction(data, params)))
     .catch(err => {
       dispatch(failureAction(err, params));
-
-      if (serviceFailureAction) {
-        dispatch(serviceFailureAction(err, params));
-      }
+      dispatch(serviceFailureAction(err, params));
 
       throw err;
     });

--- a/lib/reduxSvcClientThunk.js
+++ b/lib/reduxSvcClientThunk.js
@@ -1,3 +1,4 @@
+const get = require('lodash.get');
 const createAction = require('redux-actions').createAction;
 const GENERIC_SERVICE_FAILURE_ACTION = 'redux-svc-client-thunk/SERVICE_FAILURE';
 
@@ -23,18 +24,19 @@ function createMethodAction(action) {
   throw new TypeError('methodAction is unexpected type, must be strings or function');
 }
 
-module.exports = serviceName => (methodName, customActions = {}) => params => (dispatch, getState, services) => {
+module.exports = serviceName => (methodPath, customActions = {}) => params => (dispatch, getState, services) => {
   const {methodActions, svcClient, serviceFailureActionType} = services[serviceName];
-  const {request, success, failure} = Object.assign({}, methodActions[methodName], customActions);
+  const {request, success, failure} = Object.assign({}, get(methodActions, methodPath), customActions);
 
   const requestAction = createMethodAction(request);
   const successAction = createMethodAction(success);
   const failureAction = createMethodAction(failure);
   const serviceFailureAction = createServiceFailureAction(serviceFailureActionType);
+  const method = get(svcClient, methodPath);
 
   dispatch(requestAction(undefined, params));
 
-  return svcClient(methodName, params)
+  return method(params)
     .then(data => dispatch(successAction(data, params)))
     .catch(err => {
       dispatch(failureAction(err, params));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "nyc": "^10.1.2",
     "watch": "^1.0.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash.get": "^4.4.2"
+  },
   "scripts": {
     "ci": "npm run lint && npm run cov",
     "cov": "nyc --reporter=html --reporter=text npm test",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
   },
   "homepage": "https://github.com/CarbonLighthouse/redux-svc-client-thunk#readme",
   "devDependencies": {
-    "eslint": "^3.14.1",
-    "eslint-config-xo-space": "^0.15.0",
-    "mocha": "^3.2.0",
-    "nyc": "^10.1.2",
-    "watch": "^1.0.1"
+    "eslint": "^3.19.0",
+    "eslint-config-xo-space": "^0.16.0",
+    "mocha": "^3.4.2",
+    "nyc": "^11.0.3",
+    "sinon": "^2.3.6",
+    "watch": "^1.0.2"
   },
   "dependencies": {
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "redux-actions": "^2.0.3"
   },
   "scripts": {
     "ci": "npm run lint && npm run cov",

--- a/test/reduxSvcClientThunk.test.js
+++ b/test/reduxSvcClientThunk.test.js
@@ -1,7 +1,267 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const createServiceClientThunk = require('../lib/reduxSvcClientThunk');
+
 describe('lib/reduxSvcClientThunk', () => {
-  it('should manage successful service method call as an asynchronous redux thunk action');
-  it('should dispatch GENERIC_SERVICE_FAILURE_ACTION by default on failed service method call');
-  it('should dispatch custom serviceFailureActionType on failed service method call');
-  it('should take actions as functions');
-  it('should build action functions from "type" strings');
+  it('should manage successful service method call as an asynchronous redux thunk action', () => {
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.resolve({result: 'test.result'}))
+        },
+        methodActions: {
+          myMethod: {
+            request: 'test/REQUEST',
+            success: 'test/SUCCESS',
+            failure: 'test/FAILURE'
+          }
+        }
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    return createServiceClientThunk('testService')('myMethod')(params)(dispatch, null, services)
+      .then(() => {
+        assert(dispatch.calledTwice, 'dispatch is called twice');
+
+        const expectedRequestAction = {type: 'test/REQUEST', meta: {params}};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedSuccessAction = {
+          type: 'test/SUCCESS',
+          payload: {result: 'test.result'},
+          meta: {params}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedSuccessAction, 'dispatches success action');
+      });
+  });
+
+  it('should access methodActions and svc method via an object path', () => {
+    const services = {
+      testService: {
+        svcClient: {
+          group: {
+            myMethod: sinon.stub().returns(Promise.resolve({result: 'test.result'}))
+          }
+        },
+        methodActions: {
+          group: {
+            myMethod: {
+              request: 'test/REQUEST',
+              success: 'test/SUCCESS',
+              failure: 'test/FAILURE'
+            }
+          }
+        }
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    const path = 'group.myMethod';
+    return createServiceClientThunk('testService')(path)(params)(dispatch, null, services)
+      .then(() => {
+        assert(dispatch.calledTwice, 'dispatch is called twice');
+
+        const expectedRequestAction = {type: 'test/REQUEST', meta: {params}};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedSuccessAction = {
+          type: 'test/SUCCESS',
+          payload: {result: 'test.result'},
+          meta: {params}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedSuccessAction, 'dispatches success action');
+      });
+  });
+
+  it('should dispatch GENERIC_SERVICE_FAILURE_ACTION by default on failed service method call', () => {
+    const err = new Error('test.message');
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.reject(err))
+        },
+        methodActions: {
+          myMethod: {
+            request: 'test/REQUEST',
+            success: 'test/SUCCESS',
+            failure: 'test/FAILURE'
+          }
+        }
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    return createServiceClientThunk('testService')('myMethod')(params)(dispatch, null, services)
+      .catch(err => {
+        assert(dispatch.calledThrice, 'dispatch is called three times');
+
+        const expectedRequestAction = {type: 'test/REQUEST', meta: {params}};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedFailureAction = {
+          type: 'test/FAILURE',
+          error: true,
+          payload: err,
+          meta: {params}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedFailureAction, 'dispatches failure action');
+
+        const expectedGenericFailureAction = {
+          type: 'redux-svc-client-thunk/SERVICE_FAILURE',
+          error: true,
+          payload: err,
+          meta: {params}
+        };
+        assert.deepEqual(
+          dispatch.args[2][0],
+          expectedGenericFailureAction,
+          'dispatches generic failure'
+        );
+      });
+  });
+
+  it('should dispatch custom serviceFailureActionType on failed service method call', () => {
+    const err = new Error('test.message');
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.reject(err))
+        },
+        methodActions: {
+          myMethod: {
+            request: 'test/REQUEST',
+            success: 'test/SUCCESS',
+            failure: 'test/FAILURE'
+          }
+        },
+        serviceFailureActionType: 'test/CUSTOM_SERVICE_FAILURE'
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    return createServiceClientThunk('testService')('myMethod')(params)(dispatch, null, services)
+      .catch(err => {
+        assert(dispatch.calledThrice, 'dispatch is called three times');
+
+        const expectedRequestAction = {type: 'test/REQUEST', meta: {params}};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedFailureAction = {
+          type: 'test/FAILURE',
+          error: true,
+          payload: err,
+          meta: {params}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedFailureAction, 'dispatches failure action');
+
+        const expectedGenericFailureAction = {
+          type: 'test/CUSTOM_SERVICE_FAILURE',
+          error: true,
+          payload: err,
+          meta: {params}
+        };
+        assert.deepEqual(
+          dispatch.args[2][0],
+          expectedGenericFailureAction,
+          'dispatches custom serviceFailureActionType failure'
+        );
+      });
+  });
+
+  it('should take custom actions to override methodActions', () => {
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.resolve({result: 'test.result'}))
+        },
+        methodActions: {
+          myMethod: {
+            request: 'test/REQUEST',
+            success: 'test/SUCCESS',
+            failure: 'test/FAILURE'
+          }
+        }
+      }
+    };
+    const customActions = {success: 'custom/SUCCESS'};
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    return createServiceClientThunk('testService')('myMethod', customActions)(params)(dispatch, null, services)
+      .then(() => {
+        assert(dispatch.calledTwice, 'dispatch is called twice');
+
+        const expectedRequestAction = {type: 'test/REQUEST', meta: {params}};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedSuccessAction = {
+          type: 'custom/SUCCESS',
+          payload: {result: 'test.result'},
+          meta: {params}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedSuccessAction, 'dispatches success action');
+      });
+  });
+
+  it('should take actions functions', () => {
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.resolve({result: 'test.result'}))
+        },
+        methodActions: {
+          myMethod: {
+            request: () => ({type: 'func/REQUEST'}),
+            success: data => ({type: 'func/SUCCESS', payload: data}),
+            failure: 'test/FAILURE'
+          }
+        }
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    return createServiceClientThunk('testService')('myMethod')(params)(dispatch, null, services)
+      .then(() => {
+        assert(dispatch.calledTwice, 'dispatch is called twice');
+
+        const expectedRequestAction = {type: 'func/REQUEST'};
+        assert.deepEqual(dispatch.args[0][0], expectedRequestAction, 'dispatches request action');
+
+        const expectedSuccessAction = {
+          type: 'func/SUCCESS',
+          payload: {result: 'test.result'}
+        };
+        assert.deepEqual(dispatch.args[1][0], expectedSuccessAction, 'dispatches success action');
+      });
+  });
+
+  it('should throw exception if action is not function or string', () => {
+    const services = {
+      testService: {
+        svcClient: {
+          myMethod: sinon.stub().returns(Promise.resolve({result: 'test.result'}))
+        },
+        methodActions: {
+          request: 'test/REQUEST',
+          // An undefined action is invalid, throws error
+          success: undefined,
+          failure: 'test/FAILURE'
+        }
+      }
+    };
+    const params = {param: 'test.param'};
+    const dispatch = sinon.spy();
+
+    function harness() {
+      createServiceClientThunk('testService')('myMethod')(params)(dispatch, null, services);
+    }
+
+    assert.throws(harness, TypeError, 'methodAction is unexpected type, must be strings or function');
+  });
 });

--- a/test/reduxSvcClientThunk.test.js
+++ b/test/reduxSvcClientThunk.test.js
@@ -1,3 +1,7 @@
 describe('lib/reduxSvcClientThunk', () => {
-  it('should');
+  it('should manage successful service method call as an asynchronous redux thunk action');
+  it('should dispatch GENERIC_SERVICE_FAILURE_ACTION by default on failed service method call');
+  it('should dispatch custom serviceFailureActionType on failed service method call');
+  it('should take actions as functions');
+  it('should build action functions from "type" strings');
 });


### PR DESCRIPTION
Should be tagged as `v1.0.0`, it is a breaking change.

Coordinated with these changes svc-client v1.0.0 https://github.com/CarbonLighthouse/svc-client/pull/1 